### PR TITLE
Fix LoadingSpinner export

### DIFF
--- a/__tests__/components/LoadingSpinner.test.tsx
+++ b/__tests__/components/LoadingSpinner.test.tsx
@@ -1,6 +1,6 @@
-const React = require('react');
-const { render } = require('@testing-library/react');
-const LoadingSpinner = require('@/app/components/shared/LoadingSpinner').default;
+import React from 'react';
+import { render } from '@testing-library/react';
+import LoadingSpinner from '@/app/components/shared/LoadingSpinner';
 
 describe('LoadingSpinner Component', () => {
   it('renders without crashing', () => {

--- a/src/app/components/shared/LoadingSpinner.tsx
+++ b/src/app/components/shared/LoadingSpinner.tsx
@@ -1,12 +1,11 @@
-const React = require('react');
+import React from 'react';
 
-const LoadingSpinner = () => {
+const LoadingSpinner: React.FC = () => {
   return (
     <div className="flex items-center justify-center">
       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
     </div>
-  )
-}
+  );
+};
 
-module.exports = LoadingSpinner;
-module.exports.default = LoadingSpinner;
+export default LoadingSpinner;


### PR DESCRIPTION
## Summary
- convert LoadingSpinner to ES modules
- update test import to match

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6263853c83218e3e177a7955dfa7